### PR TITLE
Revert "Bump pytest from 7.0.1 to 7.1.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ Flask==2.0.2
 gunicorn==20.1.0
 msgpack-python==0.5.6
 requests==2.27.1  # only required for try_postcodes
-pytest==7.1.1
+pytest==7.0.1
 pytest-cov==3.0.0
 sentry-sdk[flask]==1.5.5


### PR DESCRIPTION
Reverts tutorcruncher/uk-postcode-api#99